### PR TITLE
Change "Project ID" to "Client ID"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An example Flask app demonstrating SSO with the [WorkOS Python SDK](https://gith
     ```
 1. The example app looks for the following environment variables:
     - WORKOS_API_KEY - The WorkOS API key can be found [here](https://dashboard.workos.com/api-keys).
-    - WORKOS_PROJECT_ID - The WorkOS Project ID is specific to SSO and can be found [here](https://dashboard.workos.com/sso/configuration)
+    - WORKOS_PROJECT_ID - The WorkOS Client ID is specific to SSO and can be found [here](https://dashboard.workos.com/sso/configuration)
 
 1. Follow the instructions [here](https://docs.workos.com/sso/auth-flow) on setting up an SSO connection. The redirect URL for the example app if used as is will be http://localhost:5000/auth/callback.
 


### PR DESCRIPTION
The "Client ID" section of the Configuration Settings tab in the dashboard indicates that "Project ID" has been renamed to "Client ID". This PR updates the README to reflect this change.

![Screen Shot 2021-02-08 at 7 14 28 PM](https://user-images.githubusercontent.com/12974988/107310919-3edd2c00-6a42-11eb-9ca9-1780f16a421e.png)
